### PR TITLE
Enable RGB under glow on Primus75 PCB

### DIFF
--- a/keyboards/ilumkb/primus75/config.h
+++ b/keyboards/ilumkb/primus75/config.h
@@ -36,7 +36,6 @@
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW
 
-#define LED_CAPS_LOCK_PIN B2
 #define LED_NUM_LOCK_PIN E2
 #define LED_SCROLL_LOCK_PIN F7
 #define LED_PIN_ON_STATE 0
@@ -45,6 +44,14 @@
 #define BACKLIGHT_PIN B6
 #ifdef BACKLIGHT_PIN
 #define BACKLIGHT_LEVELS 5
+#endif
+
+/* RGB Underglow */
+#define RGB_DI_PIN B2
+#ifdef RGB_DI_PIN
+#define RGBLED_NUM 16
+#define RGBLIGHT_ANIMATIONS
+#define RGBLIGHT_LAYERS
 #endif
 
 /* Set 0 if debouncing isn't needed */

--- a/keyboards/ilumkb/primus75/primus75.c
+++ b/keyboards/ilumkb/primus75/primus75.c
@@ -14,3 +14,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "primus75.h"
+
+const rgblight_segment_t PROGMEM my_capslock_layer[] = RGBLIGHT_LAYER_SEGMENTS(
+    {0, 2, HSV_WHITE}
+);
+
+const rgblight_segment_t* const PROGMEM my_rgb_layers[] = RGBLIGHT_LAYERS_LIST(
+    my_capslock_layer
+);
+void keyboard_post_init_user(void) {
+    rgblight_layers = my_rgb_layers;
+}
+
+bool led_update_user(led_t led_state) {
+    rgblight_set_layer_state(0, led_state.caps_lock);
+    return true;
+}

--- a/keyboards/ilumkb/primus75/rules.mk
+++ b/keyboards/ilumkb/primus75/rules.mk
@@ -17,5 +17,5 @@ SLEEP_LED_ENABLE = no       # Breathing sleep LED during USB suspend
 # if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 NKRO_ENABLE = yes           # USB Nkey Rollover
 BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
+RGBLIGHT_ENABLE = yes       # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output


### PR DESCRIPTION
Enable RGB under glow on Primus75 PCB by using the MOSI port.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Supports up to 16 WS2812 LEDs
It will disable the original Caps Lock LED but the under glow can show the Caps Lock status.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
